### PR TITLE
feat: 노트 리다이렉트 추가 & blog rename

### DIFF
--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -12,9 +12,16 @@ export default function Header() {
         <div className="flex items-center gap-4">
           <nav className="flex items-center space-x-6">
             <Link href="/blog" className="text-foreground hover:text-primary">
-              블로그
+              방명록
             </Link>
-            <div className="text-foreground hover:text-primary">포트폴리오</div>
+            <a
+              href="https://note.do-seung.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-foreground hover:text-primary"
+            >
+              노트
+            </a>
             <Link href="/about" className="text-foreground hover:text-primary">
               소개
             </Link>


### PR DESCRIPTION
# 블로그 -> 방명록으로 명칭이 변경됩니다.
- render server 비용 문제로 블로그는 프론트로 대체하여 다시 개발할 예정입니다.
- 방명록은 자유롭게 글을 생성할 수 있도록 개편될 예정입니다.
- 노트 카테고리가 추가되었습니다.