### PR TITLE
Refactor/notion

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ pnpm dev
 
 - `app/` 페이지 라우팅(App Router)
 - `app/_components/` 재사용 UI 컴포넌트
-- `app/blog/` 블로그 관련 페이지(목록/상세/편집)
+- `app/blog/` 블로그
+- `app/post/` 방명록
 - `app/api/` API 라우트
 - `app/util/` 테마 등 유틸
 

--- a/app/_components/RecentPostsSlider.tsx
+++ b/app/_components/RecentPostsSlider.tsx
@@ -62,7 +62,7 @@ export default function RecentPostsSlider({ posts }: RecentPostsSliderProps) {
 
       <div className="relative">
         <div className="relative h-[200px] sm:h-[240px] overflow-hidden rounded-xl bg-gradient-to-br from-slate-50 to-slate-100 dark:from-slate-900 dark:to-slate-800 border border-slate-200 dark:border-slate-700">
-          <Link href={`/blog/${posts[currentIndex].id}`}>
+          <Link href={`/post/${posts[currentIndex].id}`}>
             <AnimatePresence mode="wait">
               <motion.div
                 key={currentIndex}

--- a/app/_components/post/DeleteButton.tsx
+++ b/app/_components/post/DeleteButton.tsx
@@ -13,7 +13,7 @@ export default function EditDeleteButtons({ postId }: EditDeleteButtonsProps) {
   const [showConfirm, setShowConfirm] = useState(false);
 
   const handleEdit = () => {
-    router.push(`/blog/edit/${postId}`);
+    router.push(`/post/edit/${postId}`);
   };
 
   const handleDeleteClick = () => {
@@ -28,7 +28,7 @@ export default function EditDeleteButtons({ postId }: EditDeleteButtonsProps) {
       });
 
       if (response.ok) {
-        router.push('/blog');
+        router.push('/post');
         router.refresh();
       } else {
         throw new Error('삭제 실패');

--- a/app/_components/post/EditorHeader.tsx
+++ b/app/_components/post/EditorHeader.tsx
@@ -26,7 +26,7 @@ export default function EditorHeader({
     <header className="sticky top-0 z-10 ">
       <div className="max-w-screen-2xl mx-auto px-4 flex items-center justify-between h-16">
         <div className="flex items-center space-x-4">
-          <button onClick={() => router.push('/blog')} className="text-foreground hover:text-primary">
+          <button onClick={() => router.push('/post')} className="text-foreground hover:text-primary">
             <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
               <path
                 fillRule="evenodd"

--- a/app/api/lib/get-post.ts
+++ b/app/api/lib/get-post.ts
@@ -3,6 +3,7 @@ export interface Post {
   title: string;
   description: string;
   content?: string;
+  author?: string;
   createdAt?: string;
   updatedAt?: string;
 }

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -97,6 +97,29 @@ export default async function BlogDetailPage({ params }: { params: Promise<{ slu
       <Suspense fallback={<div className="text-muted-foreground">콘텐츠를 불러오는 중...</div>}>
         <ArticleBody contentPromise={contentPromise} />
       </Suspense>
+
+      <div className="mt-16 pt-8 border-t border-border">
+        <h2 className="text-2xl font-bold mb-6">의견 남기기</h2>
+        <div className="bg-secondary p-6 rounded-lg text-secondary-foreground">
+          <p className="mb-4">이 글에 대한 의견이나 질문이 있으시다면 언제든 연락주세요!</p>
+          <div className="flex flex-col sm:flex-row gap-4">
+            <a
+              href="/post"
+              className="inline-flex items-center px-4 py-2 border border-border rounded-lg hover:bg-muted transition"
+            >
+              <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"
+                />
+              </svg>
+              방명록에 글 남기기
+            </a>
+          </div>
+        </div>
+      </div>
     </article>
   );
 }

--- a/app/post/[id]/page.tsx
+++ b/app/post/[id]/page.tsx
@@ -18,7 +18,7 @@ export async function generateMetadata({ params }: { params: Promise<{ id: strin
     .replace(/<[^>]+>/g, ' ')
     .trim()
     .slice(0, 140);
-  const url = `https://do-seung.com/blog/${id}`;
+  const url = `https://do-seung.com/post/${id}`;
 
   return {
     title,
@@ -53,10 +53,11 @@ export default async function BlogPostPage({ params, searchParams: _searchParams
   return (
     <article className="max-w-3xl mx-auto py-10 px-6 text-foreground">
       <header className="mb-8">
-        <EditDeleteButtons postId={id} />
+        {/* <EditDeleteButtons postId={id} /> */}
         <h1 className="text-4xl font-bold mt-6 mb-2">{post.title}</h1>
 
-        <div className="flex items-center text-muted-foreground text-sm">
+        <div className="flex items-center gap-3 text-muted-foreground text-sm">
+          {post.author && <span>by {post.author}</span>}
           {post.createdAt && (
             <time dateTime={post.createdAt}>{new Date(post.createdAt).toLocaleDateString('ko-KR')}</time>
           )}
@@ -80,14 +81,14 @@ export default async function BlogPostPage({ params, searchParams: _searchParams
         <h2 className="text-2xl font-bold mb-6">이런 글도 읽어보세요</h2>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           <Link
-            href="/blog/1"
+            href="/post/1"
             className="block p-4 border border-border bg-card text-card-foreground rounded-lg hover:shadow-md transition"
           >
             <h3 className="font-medium text-lg mb-1 hover:text-primary">첫 번째 추천 게시글</h3>
             <p className="text-muted-foreground text-sm">간략한 설명이 들어갑니다...</p>
           </Link>
           <Link
-            href="/blog/2"
+            href="/post/2"
             className="block p-4 border border-border bg-card text-card-foreground rounded-lg hover:shadow-md transition"
           >
             <h3 className="font-medium text-lg mb-1 hover:text-primary">두 번째 추천 게시글</h3>
@@ -104,9 +105,9 @@ export default async function BlogPostPage({ params, searchParams: _searchParams
             headline: post.title,
             datePublished: post.createdAt,
             dateModified: post.updatedAt || post.createdAt,
-            author: [{ '@type': 'Person', name: 'Doseung Yang' }],
+            author: post.author ? [{ '@type': 'Person', name: post.author }] : undefined,
             publisher: { '@type': 'Organization', name: '개발자 도승' },
-            mainEntityOfPage: `https://do-seung.com/blog/${id}`,
+            mainEntityOfPage: `https://do-seung.com/post/${id}`,
           }).replace(/</g, '\\u003c'),
         }}
       />
@@ -116,8 +117,8 @@ export default async function BlogPostPage({ params, searchParams: _searchParams
           __html: JSON.stringify({
             '@context': 'https://schema.org',
             '@type': 'CollectionPage',
-            name: '블로그',
-            url: 'https://do-seung.com/blog',
+            name: '방명록',
+            url: 'https://do-seung.com/post',
             isPartOf: { '@type': 'WebSite', url: 'https://do-seung.com' },
           }).replace(/</g, '\\u003c'),
         }}

--- a/app/post/edit/[id]/page.tsx
+++ b/app/post/edit/[id]/page.tsx
@@ -12,6 +12,7 @@ export default function EditPostPage({ params }: { params: { id: string } }) {
 
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
+  const [author, setAuthor] = useState('');
   const [isSaving, setIsSaving] = useState(false);
   const [isPublishing, setIsPublishing] = useState(false);
   const [savedStatus, setSavedStatus] = useState('');
@@ -29,6 +30,7 @@ export default function EditPostPage({ params }: { params: { id: string } }) {
         const post = await response.json();
 
         setTitle(post.title || '');
+        setAuthor(post.author || '');
 
         if (post.content) {
           try {
@@ -43,7 +45,7 @@ export default function EditPostPage({ params }: { params: { id: string } }) {
       } catch (error) {
         console.error('Error fetching post:', error);
         alert('게시글을 불러오는데 실패했습니다.');
-        router.push('/blog');
+        router.push('/post');
       }
     }
 
@@ -77,6 +79,7 @@ export default function EditPostPage({ params }: { params: { id: string } }) {
         body: JSON.stringify({
           title,
           content: processedContent,
+          author,
           published: publish,
         }),
       });
@@ -88,7 +91,7 @@ export default function EditPostPage({ params }: { params: { id: string } }) {
       const data = await response.json();
 
       if (publish) {
-        router.push(`/blog/${data.id || postId}`);
+        router.push(`/post/${data.id || postId}`);
       } else {
         setSavedStatus('저장됨');
         setTimeout(() => setSavedStatus(''), 5000);
@@ -125,6 +128,12 @@ export default function EditPostPage({ params }: { params: { id: string } }) {
       />
 
       <div className="max-w-4xl mx-auto px-4 py-8">
+        <label className="block text-sm font-medium mb-2">작성자(닉네임)</label>
+        <input
+          value={author}
+          onChange={e => setAuthor(e.target.value)}
+          className="w-full mb-6 px-3 py-2 rounded-md border border-border bg-background text-foreground"
+        />
         <TitleEditor value={title} onChange={setTitle} />
         <div className="border-b border-border mb-6"></div>
         <ContentEditor value={content} onChange={setContent} />

--- a/app/post/edit/page.tsx
+++ b/app/post/edit/page.tsx
@@ -10,6 +10,7 @@ export default function EditPage() {
   const router = useRouter();
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
+  const [author, setAuthor] = useState('');
   const [isSaving, setIsSaving] = useState(false);
   const [isPublishing, setIsPublishing] = useState(false);
   const [savedStatus, setSavedStatus] = useState('');
@@ -41,6 +42,7 @@ export default function EditPage() {
         body: JSON.stringify({
           title,
           content,
+          author,
           published: publish,
         }),
       });
@@ -52,7 +54,7 @@ export default function EditPage() {
       const data = await response.json();
 
       if (publish) {
-        router.push(`/blog/${data.id}`);
+        router.push(`/post/${data.id}`);
       } else {
         setSavedStatus('저장됨');
         setTimeout(() => setSavedStatus(''), 5000);
@@ -77,6 +79,12 @@ export default function EditPage() {
       />
 
       <div className="max-w-4xl mx-auto px-4 py-8">
+        <label className="block text-sm font-medium mb-2">작성자(닉네임)</label>
+        <input
+          value={author}
+          onChange={e => setAuthor(e.target.value)}
+          className="w-fit mb-6 px-3 py-2 rounded-md border border-border bg-background text-foreground"
+        />
         <TitleEditor value={title} onChange={setTitle} />
         <div className="border-b border-border mb-6"></div>
         <ContentEditor value={content} onChange={setContent} />

--- a/app/post/page.tsx
+++ b/app/post/page.tsx
@@ -18,9 +18,9 @@ function stripHtml(html: string | undefined): string {
   return result.replace(/\s+/g, ' ').trim();
 }
 export const metadata = {
-  title: '양도승 | 기술 블로그',
-  description: '양도승 기술 블로그',
-  alternates: { canonical: '/blog' },
+  title: '양도승 | 기술 블로그 방명록',
+  description: '양도승 기술 블로그 방명록',
+  alternates: { canonical: '/post' },
 };
 
 export default async function BlogPage() {
@@ -29,9 +29,9 @@ export default async function BlogPage() {
   return (
     <div className="max-w-3xl mx-auto p-6 text-foreground">
       <div className="flex justify-between items-center mb-6">
-        <h1 className="text-3xl font-bold">블로그</h1>
+        <h1 className="text-3xl font-bold">방명록</h1>
         <Link
-          href="/blog/edit"
+          href="/post/edit"
           className="bg-primary hover:opacity-90 text-primary-foreground px-4 py-2 rounded-lg text-sm font-medium"
         >
           새 글 작성
@@ -45,8 +45,9 @@ export default async function BlogPage() {
               key={post.id}
               className="border border-border bg-card text-card-foreground p-4 rounded-lg hover:shadow-md transition"
             >
-              <Link href={`/blog/${post.id}`} className="block">
+              <Link href={`/post/${post.id}`} className="block">
                 <h2 className="text-xl font-semibold">{post.title}</h2>
+                {post.author && <p className="mt-1 text-sm text-muted-foreground">by {post.author}</p>}
                 <p className="text-muted-foreground line-clamp-2 mt-2">{stripHtml(post.content)}</p>
                 {post.createdAt && (
                   <p className="text-sm text-muted-foreground mt-2">

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -19,7 +19,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       priority: 0.8,
     },
     {
-      url: `${baseUrl}/blog`,
+      url: `${baseUrl}/post`,
       lastModified: now,
       changeFrequency: 'daily',
       priority: 0.9,
@@ -28,7 +28,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
   const posts = await getPosts();
   const postEntries: MetadataRoute.Sitemap = (posts || []).map(p => ({
-    url: `${baseUrl}/blog/${p.id}`,
+    url: `${baseUrl}/post/${p.id}`,
     lastModified: new Date(p.updatedAt || p.createdAt || now.toISOString()),
     changeFrequency: 'weekly',
     priority: 0.7,


### PR DESCRIPTION
- notion 호출 헬퍼를 unstable_cache로 캐핑해 서버 캐시를 적용하여 캐시를 최적화합니다.
Suspense를 통해 렌더링을 진행하여 TTFB를 단축합니다.
만약 slug가 notion UUID로 진입된다면 pages.retrieve로 즉시 조회를 진행하여 N+1 조회를 막습니다.