### PR TITLE
refactor: seo 구조 리펙토링

### DIFF
--- a/app/api/lib/notion.ts
+++ b/app/api/lib/notion.ts
@@ -12,12 +12,19 @@ export type NotionPost = {
   date?: string;
   published: boolean;
   coverUrl?: string;
+  lastEditedTime?: string;
 };
+
+type NotionPageCover =
+  | { type: 'external'; external: { url: string } }
+  | { type: 'file'; file: { url: string } };
 
 type NotionPage = {
   id: string;
   properties: Record<string, NotionProperty>;
   created_time: string;
+  last_edited_time?: string;
+  cover?: NotionPageCover;
 };
 
 type NotionProperty =
@@ -98,8 +105,16 @@ function mapPageToPost(page: NotionPage): NotionPost {
   if (pubProp?.type === 'checkbox') {
     published = pubProp.checkbox;
   }
-  
-  return { id: page.id, title, slug, description, tags, date, published, coverUrl: undefined };
+
+  const lastEditedTime = page.last_edited_time ?? page.created_time;
+  const coverUrl =
+    page.cover?.type === 'external'
+      ? page.cover.external.url
+      : page.cover?.type === 'file'
+        ? page.cover.file.url
+        : undefined;
+
+  return { id: page.id, title, slug, description, tags, date, published, coverUrl, lastEditedTime };
 }
 
 async function _getPosts(options?: { pageSize?: number; startCursor?: string | null }) {

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,15 +1,19 @@
 import type { Metadata } from 'next';
 import { getPosts } from '@/app/api/lib/notion';
 import BlogGallery from './_components/BlogGallery';
+import { SITE_URL } from '@/app/constants/site';
+
+const BLOG_TITLE = '블로그 | 개발자 도승';
+const BLOG_DESCRIPTION = '개발하며 새롭게 습득한 지식과 배운 내용을 공유합니다.';
 
 export const metadata: Metadata = {
-  title: '블로그 | 개발자 도승',
-  description: '개발과 일상에서 얻은 경험과 배움을 정리한 글을 공유합니다.',
-  alternates: { canonical: '/blog' },
+  title: BLOG_TITLE,
+  description: BLOG_DESCRIPTION,
+  alternates: { canonical: `${SITE_URL}/blog` },
   openGraph: {
-    title: '블로그 | 개발자 도승',
-    description: '개발과 일상에서 얻은 경험과 배움을 정리한 글을 공유합니다.',
-    url: '/blog',
+    title: BLOG_TITLE,
+    description: BLOG_DESCRIPTION,
+    url: `${SITE_URL}/blog`,
     siteName: '개발자 도승',
     images: ['/DS.png'],
     type: 'website',
@@ -17,19 +21,34 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: 'summary_large_image',
-    title: '블로그 | 개발자 도승',
-    description: '개발과 일상에서 얻은 경험과 배움을 정리한 글을 공유합니다.',
+    title: BLOG_TITLE,
+    description: BLOG_DESCRIPTION,
     images: ['/DS.png'],
   },
 };
 
 export const revalidate = 60;
 
+const blogIndexBreadcrumbJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: '홈', item: SITE_URL },
+    { '@type': 'ListItem', position: 2, name: '블로그', item: `${SITE_URL}/blog` },
+  ],
+};
+
 export default async function BlogIndexPage() {
   const { posts, hasMore, nextCursor } = await getPosts({ pageSize: 20 });
 
   return (
     <section className="max-w-4xl mx-auto py-10 px-6 text-foreground">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(blogIndexBreadcrumbJsonLd).replace(/</g, '\\u003c'),
+        }}
+      />
       <div className="mb-12">
         <h1 className="text-4xl font-bold mb-4">블로그</h1>
         <p className="text-xl text-muted-foreground">개발과 일상에 대한 이야기를 기록합니다</p>

--- a/app/constants/site.ts
+++ b/app/constants/site.ts
@@ -1,0 +1,8 @@
+export const SITE_URL = 'https://do-seung.com';
+
+export const SITE_TITLE = '양도승 | 개발자 도승 - 기술 블로그';
+
+export const SITE_DESCRIPTION =
+  '웹 개발자 양도승 입니다. 공부하며 배운 내용을 공유합니다.';
+
+export const SITE_KEYWORDS = ['양도승', '도승', '개발자 도승', '기술 블로그', '웹 개발'] as const;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,11 +3,13 @@ import './globals.css';
 import Header from './components/Header';
 import Footer from './components/Footer';
 import { ThemeProvider } from './util/theme-provider';
+import { SITE_URL, SITE_TITLE, SITE_DESCRIPTION, SITE_KEYWORDS } from './constants/site';
 
 export const metadata: Metadata = {
-  title: '개발자 도승',
-  description: '개발자 양도승 기술 블로그',
-  authors: [{ name: '양도승', url: 'https://do-seung.com' }],
+  title: SITE_TITLE,
+  description: SITE_DESCRIPTION,
+  keywords: [...SITE_KEYWORDS],
+  authors: [{ name: '양도승', url: SITE_URL }],
   creator: '양도승',
   publisher: '양도승',
   icons: {
@@ -16,10 +18,10 @@ export const metadata: Metadata = {
     apple: '/DS.png',
   },
   openGraph: {
-    title: '개발자 도승',
-    description: '개발자 양도승 기술 블로그',
-    url: 'https://do-seung.com',
-    siteName: '개발자 도승',
+    title: SITE_TITLE,
+    description: SITE_DESCRIPTION,
+    url: SITE_URL,
+    siteName: SITE_TITLE,
     images: [
       {
         url: '/DS.png',
@@ -33,12 +35,12 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: 'summary_large_image',
-    title: '개발자 도승',
-    description: '개발자 양도승 기술 블로그.',
+    title: SITE_TITLE,
+    description: SITE_DESCRIPTION,
     images: ['/DS.png'],
   },
   robots: 'index, follow',
-  metadataBase: new URL('https://do-seung.com'),
+  metadataBase: new URL(SITE_URL),
 };
 
 export default function RootLayout({ children }: Readonly<{ children: React.ReactNode }>) {
@@ -48,8 +50,6 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
         <meta name="naver-site-verification" content="85aa45c91ab7900ee949467cdf8ec36f42e79d36" />
         <link rel="icon" href="/favicon.ico" sizes="32x32" type="image/png" />
         <link rel="apple-touch-icon" href="/DS.png" />
-        <meta property="og:image" content="/DS.png" />
-        <meta name="twitter:image" content="/DS.png" />
         <meta name="google-site-verification" content="EPVuKhsslwvvX5ZfwzlyIxMqrdlf6-_7qUGaVmmNhy0" />
       </head>
       <body className="bg-background text-foreground">
@@ -63,10 +63,35 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
           dangerouslySetInnerHTML={{
             __html: JSON.stringify({
               '@context': 'https://schema.org',
-              '@type': 'Organization',
-              name: '양도승',
-              url: 'https://do-seung.com',
-              logo: 'https://do-seung.com/DS.png',
+              '@graph': [
+                {
+                  '@type': 'Organization',
+                  '@id': `${SITE_URL}/#organization`,
+                  name: '양도승',
+                  url: SITE_URL,
+                  logo: `${SITE_URL}/DS.png`,
+                },
+                {
+                  '@type': 'Person',
+                  '@id': `${SITE_URL}/#person`,
+                  name: '양도승',
+                  alternateName: '도승',
+                  url: SITE_URL,
+                  sameAs: [
+                    'https://github.com/Doseung-Yang',
+                    'https://x.com/DoseungYang',
+                  ],
+                },
+                {
+                  '@type': 'WebSite',
+                  '@id': `${SITE_URL}/#website`,
+                  url: SITE_URL,
+                  name: '양도승 블로그',
+                  alternateName: '도승 블로그',
+                  description: SITE_DESCRIPTION,
+                  publisher: { '@id': `${SITE_URL}/#organization` },
+                },
+              ],
             }).replace(/</g, '\\u003c'),
           }}
         />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,29 @@
+import type { Metadata } from 'next';
 import { Suspense } from 'react';
 import HeroSection from './_components/HeroSection';
 import SkillsSection from './_components/SkillsSection';
 import RecentPostsSlider from './_components/RecentPostsSlider';
 import { getPosts } from './api/lib/notion';
+import { SITE_URL, SITE_TITLE, SITE_DESCRIPTION, SITE_KEYWORDS } from './constants/site';
+
+export const metadata: Metadata = {
+  title: SITE_TITLE,
+  description: SITE_DESCRIPTION,
+  keywords: [...SITE_KEYWORDS],
+  openGraph: {
+    title: SITE_TITLE,
+    description: SITE_DESCRIPTION,
+    url: SITE_URL,
+    siteName: SITE_TITLE,
+    type: 'website',
+    locale: 'ko_KR',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: SITE_TITLE,
+    description: SITE_DESCRIPTION,
+  },
+};
 
 function SliderSkeleton() {
   return (

--- a/app/post/[id]/page.tsx
+++ b/app/post/[id]/page.tsx
@@ -3,6 +3,7 @@ import CommentsSection from '@/app/_components/post/CommentsSection';
 import { getPost, getCommentsByPostId } from '@/app/api/lib/get-post';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
+import { SITE_URL } from '@/app/constants/site';
 
 type PageProps = {
   params: Promise<{ id: string }>;
@@ -17,7 +18,7 @@ export async function generateMetadata({ params }: { params: Promise<{ id: strin
     .replace(/<[^>]+>/g, ' ')
     .trim()
     .slice(0, 140);
-  const url = `https://do-seung.com/post/${id}`;
+  const url = `${SITE_URL}/post/${id}`;
 
   return {
     title,
@@ -108,7 +109,7 @@ export default async function BlogPostPage({ params }: PageProps) {
             dateModified: post.updatedAt || post.createdAt,
             author: post.author ? [{ '@type': 'Person', name: post.author }] : undefined,
             publisher: { '@type': 'Organization', name: '개발자 도승' },
-            mainEntityOfPage: `https://do-seung.com/post/${id}`,
+            mainEntityOfPage: `${SITE_URL}/post/${id}`,
           }).replace(/</g, '\\u003c'),
         }}
       />
@@ -119,8 +120,8 @@ export default async function BlogPostPage({ params }: PageProps) {
             '@context': 'https://schema.org',
             '@type': 'CollectionPage',
             name: '방명록',
-            url: 'https://do-seung.com/post',
-            isPartOf: { '@type': 'WebSite', url: 'https://do-seung.com' },
+            url: `${SITE_URL}/post`,
+            isPartOf: { '@type': 'WebSite', url: SITE_URL },
           }).replace(/</g, '\\u003c'),
         }}
       />

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,7 +1,9 @@
+import { SITE_URL } from '@/app/constants/site';
+
 export default function robots() {
   return {
     rules: [{ userAgent: '*', allow: '/' }],
-    sitemap: 'https://do-seung.com/sitemap.xml',
-    host: 'https://do-seung.com',
+    sitemap: `${SITE_URL}/sitemap.xml`,
+    host: SITE_URL,
   };
 }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,50 +1,53 @@
 import { MetadataRoute } from 'next';
 import { getPosts as getGuestbookPosts } from '@/app/api/lib/get-post';
 import { getPosts as getBlogPosts, getPostUrl } from '@/app/api/lib/notion';
+import { SITE_URL } from '@/app/constants/site';
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const baseUrl = 'https://do-seung.com';
   const now = new Date();
 
   const staticEntries: MetadataRoute.Sitemap = [
     {
-      url: `${baseUrl}/`,
+      url: `${SITE_URL}/`,
       lastModified: now,
       changeFrequency: 'daily',
       priority: 1.0,
     },
     {
-      url: `${baseUrl}/blog`,
+      url: `${SITE_URL}/blog`,
       lastModified: now,
       changeFrequency: 'daily',
       priority: 0.9,
     },
     {
-      url: `${baseUrl}/about`,
+      url: `${SITE_URL}/about`,
       lastModified: now,
       changeFrequency: 'monthly',
       priority: 0.8,
     },
     {
-      url: `${baseUrl}/post`,
+      url: `${SITE_URL}/post`,
       lastModified: now,
       changeFrequency: 'daily',
       priority: 0.9,
     },
   ];
 
-  const guestbookPosts = await getGuestbookPosts();
+  const [guestbookPosts, { posts: blogPosts }] = await Promise.all([
+    getGuestbookPosts(),
+    getBlogPosts({ pageSize: 50 }),
+  ]);
+
   const guestbookEntries: MetadataRoute.Sitemap = (guestbookPosts || []).map(p => ({
-    url: `${baseUrl}/post/${p.id}`,
+    url: `${SITE_URL}/post/${p.id}`,
     lastModified: new Date(p.updatedAt || p.createdAt || now.toISOString()),
     changeFrequency: 'weekly',
     priority: 0.7,
   }));
 
-  const { posts: blogPosts } = await getBlogPosts({ pageSize: 50 });
   const blogEntries: MetadataRoute.Sitemap = (blogPosts || []).map(post => ({
-    url: `${baseUrl}${getPostUrl(post.slug)}`,
-    lastModified: new Date(post.date || now.toISOString()),
+    url: `${SITE_URL}${getPostUrl(post.slug)}`,
+    lastModified: new Date(post.lastEditedTime || post.date || now.toISOString()),
     changeFrequency: 'weekly',
     priority: 0.8,
   }));


### PR DESCRIPTION
## 요약

"구글 스니펫 품질 개선, 블로그 글 스니펫 노출을 위한 SEO 보강 및 상수화·병렬 fetch·조건부 렌더 정리 반영.

---

## SEO

- **홈·레이아웃 메타**: `양도승 | 개발자 도승 - 기술 블로그` 등 공통 문구·키워드 정리, OG/twitter 메타 통일
- **구조화 데이터**: 루트에 WebSite·Person(alternateName: 도승)·Organization, 블로그 글에 BlogPosting + BreadcrumbList(`@graph` 한 스크립트)
- **블로그 글**: BlogPosting, `siteName`, 메타 설명 155자 이내, 글별 `coverUrl`(Notion cover)·`lastEditedTime`(Notion last_edited_time) 반영
- **사이트맵**: 블로그 항목 `lastModified`에 `lastEditedTime` 사용

---

## 리팩터링

- **상수**: `app/constants/site.ts`에 `SITE_URL`, `SITE_TITLE`, `SITE_DESCRIPTION`, `SITE_KEYWORDS` 정의 후 layout·page·blog·sitemap·robots·post에서 import
- **사이트맵**: 방명록·블로그 목록 fetch를 `Promise.all`로 병렬화
- **블로그 목록**: canonical·OG url을 절대 URL(`${SITE_URL}/blog`)로 변경
- **블로그 글**: `post.description` / `post.date` / `post.tags` 조건부 렌더를 `&&` → 삼항 연산자로 통일

---

## 변경 파일

| 경로 | 변경 내용 |
|------|------------|
| `app/constants/site.ts` | 신규. SITE_URL, SITE_TITLE, SITE_DESCRIPTION, SITE_KEYWORDS |
| `app/page.tsx` | 홈 메타(상수 사용) |
| `app/layout.tsx` | 메타·JSON-LD 상수 사용, head 내 중복 og/twitter image 제거 |
| `app/blog/page.tsx` | 메타·BreadcrumbList에 SITE_URL, canonical 절대 URL |
| `app/blog/[slug]/page.tsx` | BlogPosting·BreadcrumbList @graph 통합, 상수 사용, 조건부 렌더 삼항화 |
| `app/api/lib/notion.ts` | NotionPost에 lastEditedTime·coverUrl, Notion cover 매핑 |
| `app/sitemap.ts` | SITE_URL 사용, 방명록·블로그 fetch Promise.all 병렬화 |
| `app/robots.ts` | SITE_URL 사용 |
| `app/post/[id]/page.tsx` | SITE_URL 사용 |